### PR TITLE
Removed cast to IJSInProcessRuntime

### DIFF
--- a/src/Blazor.Extensions.SignalR/HubConnection.cs
+++ b/src/Blazor.Extensions.SignalR/HubConnection.cs
@@ -28,7 +28,7 @@ namespace Blazor.Extensions
         {
             this.Options = options;
             this.InternalConnectionId = Guid.NewGuid().ToString();
-            ((IJSInProcessRuntime)JSRuntime.Current).Invoke<object>(CREATE_CONNECTION_METHOD,
+            JSRuntime.Current.InvokeSync<object>(CREATE_CONNECTION_METHOD,
                 this.InternalConnectionId,
                 new DotNetObjectRef(this.Options));
         }
@@ -163,7 +163,7 @@ namespace Blazor.Extensions
                 };
             }
 
-            ((IJSInProcessRuntime)JSRuntime.Current).Invoke<object>(ON_METHOD, this.InternalConnectionId, new DotNetObjectRef(callback));
+            JSRuntime.Current.InvokeSync<object>(ON_METHOD, this.InternalConnectionId, new DotNetObjectRef(callback));
         }
 
         internal void RemoveHandle(string methodName, string callbackId)
@@ -172,7 +172,7 @@ namespace Blazor.Extensions
             {
                 if (callbacks.TryGetValue(callbackId, out var callback))
                 {
-                    ((IJSInProcessRuntime)JSRuntime.Current).Invoke<object>(OFF_METHOD, this.InternalConnectionId, methodName, callbackId);
+                    JSRuntime.Current.InvokeSync<object>(OFF_METHOD, this.InternalConnectionId, methodName, callbackId);
                     //HubConnectionManager.Off(this.InternalConnectionId, handle.Item1);
                     callbacks.Remove(callbackId);
 
@@ -187,7 +187,7 @@ namespace Blazor.Extensions
         public void OnClose(Func<Exception, Task> callback)
         {
             this._closeCallback = new HubCloseCallback(callback);
-            ((IJSInProcessRuntime)JSRuntime.Current).Invoke<object>(ON_CLOSE_METHOD,
+            JSRuntime.Current.InvokeSync<object>(ON_CLOSE_METHOD,
                 this.InternalConnectionId,
                 new DotNetObjectRef(this._closeCallback));
         }
@@ -198,6 +198,6 @@ namespace Blazor.Extensions
         public Task<TResult> InvokeAsync<TResult>(string methodName, params object[] args) =>
             JSRuntime.Current.InvokeAsync<TResult>(INVOKE_WITH_RESULT_ASYNC_METHOD, this.InternalConnectionId, methodName, args);
 
-        public void Dispose() => ((IJSInProcessRuntime)JSRuntime.Current).Invoke<object>(REMOVE_CONNECTION_METHOD, this.InternalConnectionId);
+        public void Dispose() => JSRuntime.Current.InvokeSync<object>(REMOVE_CONNECTION_METHOD, this.InternalConnectionId);
     }
 }

--- a/src/Blazor.Extensions.SignalR/JSRuntimeExtensions.cs
+++ b/src/Blazor.Extensions.SignalR/JSRuntimeExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using Microsoft.JSInterop;
+
+namespace Blazor.Extensions
+{
+    internal static class JSRuntimeExtensions
+    {
+        public static T InvokeSync<T>(this IJSRuntime jsRuntime, string identifier, params object[] args)
+        {
+            if (jsRuntime == null)
+                throw new ArgumentNullException(nameof(jsRuntime));
+
+            if (jsRuntime is IJSInProcessRuntime inProcessJsRuntime)
+            {
+                return inProcessJsRuntime.Invoke<T>(identifier, args);
+            }
+
+            return jsRuntime.InvokeAsync<T>(identifier, args).ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+    }
+}


### PR DESCRIPTION
Added a helper type to replace the fix casts to `IJSInProcessRuntime` that checks the actual type of js runtime and provides a workaround if necessary.
This fixes #16.