### PR TITLE
Support for byte arrays. Fixes #19

### DIFF
--- a/test/Blazor.Extensions.SignalR.Test.Client/Pages/Chat.cshtml
+++ b/test/Blazor.Extensions.SignalR.Test.Client/Pages/Chat.cshtml
@@ -18,6 +18,14 @@
     </div>
 </form>
 
+<h4>Byte array Arguments</h4>
+<form class="form-inline">
+    <div class="input-append">
+        <input type="button" class="btn" value="Gimme byte array arguments!" onclick=@DoByteArrayArg />
+
+    </div>
+</form>
+
 <h4>To Everybody</h4>
 <form class="form-inline">
     <div class="input-append">

--- a/test/Blazor.Extensions.SignalR.Test.Client/Pages/ChatComponent.cs
+++ b/test/Blazor.Extensions.SignalR.Test.Client/Pages/ChatComponent.cs
@@ -25,6 +25,7 @@ namespace Blazor.Extensions.SignalR.Test.Client.Pages
         private IDisposable _listHandle;
         private IDisposable _multiArgsHandle;
         private IDisposable _multiArgsComplexHandle;
+        private IDisposable _byteArrayHandle;
         private HubConnection _connection;
 
         protected override async Task OnInitAsync()
@@ -87,6 +88,14 @@ namespace Blazor.Extensions.SignalR.Test.Client.Pages
             this._multiArgsComplexHandle.Dispose();
 
             return this.HandleArgs(arg1, arg2);
+        }
+
+        public Task DemoByteArrayArg(byte[] array)
+        {
+            this._logger.LogInformation("Got byte array!");
+            this._byteArrayHandle.Dispose();
+
+            return this.HandleArgs(BitConverter.ToString(array));
         }
 
         private async Task<string> GetJwtToken(string userId)
@@ -160,6 +169,14 @@ namespace Blazor.Extensions.SignalR.Test.Client.Pages
             this._multiArgsComplexHandle = this._connection.On<DemoData, DemoData[]>("DemoMultiArgs2", this.DemoMultipleArgsComplex);
             await this._connection.InvokeAsync("DoMultipleArgs");
             await this._connection.InvokeAsync("DoMultipleArgsComplex");
+        }
+
+        internal async Task DoByteArrayArg()
+        {
+            this._byteArrayHandle = this._connection.On<byte[]>("DemoByteArrayArg", this.DemoByteArrayArg);
+            var array = await this._connection.InvokeAsync<byte[]>("DoByteArrayArg");
+
+            this._logger.LogInformation("Got byte returned from hub method array: {0}", BitConverter.ToString(array));
         }
 
         internal async Task TellHubToDoStuff()

--- a/test/Blazor.Extensions.SignalR.Test.Server/Blazor.Extensions.SignalR.Test.Server.csproj
+++ b/test/Blazor.Extensions.SignalR.Test.Server/Blazor.Extensions.SignalR.Test.Server.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.4" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="0.6.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="1.0.2" />
   </ItemGroup>
 

--- a/test/Blazor.Extensions.SignalR.Test.Server/Hubs/ChatHub.cs
+++ b/test/Blazor.Extensions.SignalR.Test.Server/Hubs/ChatHub.cs
@@ -27,6 +27,15 @@ namespace Blazor.Extensions.SignalR.Test.Server.Hubs
             await this.Clients.Others.SendAsync("Send", $"{this.Context.ConnectionId} left");
         }
 
+        public async Task<byte[]> DoByteArrayArg()
+        {
+            var array = new byte[] { 1, 2, 3 };
+
+            await this.Clients.All.SendAsync("DemoByteArrayArg", array);
+
+            return array;
+        }
+
         public Task DoMultipleArgs()
         {
             return this.Clients.All.SendAsync("DemoMultiArgs", "one", 2, "three", 4);


### PR DESCRIPTION
I added a test case that shows the usage of a `byte[]` as hub handler result and as client handler argument. The fix translates all `TypedArray`s to ordinary arrays, which is quire inefficient but seems the best possible solution, since SimpleJson does not have support for `TypedArray`s at the moment.  

Other array types like `short[]`, `int[]`, etc. should also work but were not tested.

This fixes #19.