### PR TITLE
Make JSON property names parsing case-insensitive

### DIFF
--- a/src/Blazor.Extensions.SignalR/HubConnection.cs
+++ b/src/Blazor.Extensions.SignalR/HubConnection.cs
@@ -102,45 +102,47 @@ namespace Blazor.Extensions
                      TResult9 t9 = default;
                      TResult10 t10 = default;
 
+                     var serializerOptions = new JsonSerializerOptions() { PropertyNameCaseInsensitive = true };
+
                      if (payloads.Length > 0)
                      {
-                         t1 = JsonSerializer.Parse<TResult1>(payloads[0]);
+                         t1 = JsonSerializer.Parse<TResult1>(payloads[0], serializerOptions);
                      }
                      if (payloads.Length > 1)
                      {
-                         t2 = JsonSerializer.Parse<TResult2>(payloads[1]);
+                         t2 = JsonSerializer.Parse<TResult2>(payloads[1], serializerOptions);
                      }
                      if (payloads.Length > 2)
                      {
-                         t3 = JsonSerializer.Parse<TResult3>(payloads[2]);
+                         t3 = JsonSerializer.Parse<TResult3>(payloads[2], serializerOptions);
                      }
                      if (payloads.Length > 3)
                      {
-                         t4 = JsonSerializer.Parse<TResult4>(payloads[3]);
+                         t4 = JsonSerializer.Parse<TResult4>(payloads[3], serializerOptions);
                      }
                      if (payloads.Length > 4)
                      {
-                         t5 = JsonSerializer.Parse<TResult5>(payloads[4]);
+                         t5 = JsonSerializer.Parse<TResult5>(payloads[4], serializerOptions);
                      }
                      if (payloads.Length > 5)
                      {
-                         t6 = JsonSerializer.Parse<TResult6>(payloads[5]);
+                         t6 = JsonSerializer.Parse<TResult6>(payloads[5], serializerOptions);
                      }
                      if (payloads.Length > 6)
                      {
-                         t7 = JsonSerializer.Parse<TResult7>(payloads[6]);
+                         t7 = JsonSerializer.Parse<TResult7>(payloads[6], serializerOptions);
                      }
                      if (payloads.Length > 7)
                      {
-                         t8 = JsonSerializer.Parse<TResult8>(payloads[7]);
+                         t8 = JsonSerializer.Parse<TResult8>(payloads[7], serializerOptions);
                      }
                      if (payloads.Length > 8)
                      {
-                         t9 = JsonSerializer.Parse<TResult9>(payloads[8]);
+                         t9 = JsonSerializer.Parse<TResult9>(payloads[8], serializerOptions);
                      }
                      if (payloads.Length > 9)
                      {
-                         t10 = JsonSerializer.Parse<TResult10>(payloads[9]);
+                         t10 = JsonSerializer.Parse<TResult10>(payloads[9], serializerOptions);
                      }
 
                      return handler(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10);


### PR DESCRIPTION
By default, when serializing object on server side, SignalR uses
case-insensitive option and properties are all made lowercase.

Deserialization on the client side in native .NET client is also
case-insensitive.

We should have the same behavior as the default client. Otherwise,
deserialization of objects will be broken in most common scenarios.
That is when user uses ASP.NET Core SignalR server and has property
names in object sent through SinglaR starting with uppercase letter.

Fixes #39 