### PR TITLE
Added support for custom Json serializer options

### DIFF
--- a/src/Blazor.Extensions.SignalR/HttpConnectionOptions.cs
+++ b/src/Blazor.Extensions.SignalR/HttpConnectionOptions.cs
@@ -13,6 +13,7 @@ namespace Blazor.Extensions
         public bool EnableMessagePack { [JSInvokable]get; set; }
         public string Url { [JSInvokable]get; set; }
         public Func<Task<string>> AccessTokenProvider { get; set; }
+        public JsonHubProtocolOptions JsonHubProtocolOptions { get; set; } = new JsonHubProtocolOptions();
 
         [JSInvokable]
         public Task<string> GetAccessToken() => this.AccessTokenProvider?.Invoke();

--- a/src/Blazor.Extensions.SignalR/HubConnection.cs
+++ b/src/Blazor.Extensions.SignalR/HubConnection.cs
@@ -105,43 +105,43 @@ namespace Blazor.Extensions
 
                      if (payloads.Length > 0)
                      {
-                         t1 = JsonSerializer.Deserialize<TResult1>(payloads[0]);
+                         t1 = JsonSerializer.Deserialize<TResult1>(payloads[0], this.Options.JsonHubProtocolOptions.PayloadSerializerOptions);
                      }
                      if (payloads.Length > 1)
                      {
-                         t2 = JsonSerializer.Deserialize<TResult2>(payloads[1]);
+                         t2 = JsonSerializer.Deserialize<TResult2>(payloads[1], this.Options.JsonHubProtocolOptions.PayloadSerializerOptions);
                      }
                      if (payloads.Length > 2)
                      {
-                         t3 = JsonSerializer.Deserialize<TResult3>(payloads[2]);
+                         t3 = JsonSerializer.Deserialize<TResult3>(payloads[2], this.Options.JsonHubProtocolOptions.PayloadSerializerOptions);
                      }
                      if (payloads.Length > 3)
                      {
-                         t4 = JsonSerializer.Deserialize<TResult4>(payloads[3]);
+                         t4 = JsonSerializer.Deserialize<TResult4>(payloads[3], this.Options.JsonHubProtocolOptions.PayloadSerializerOptions);
                      }
                      if (payloads.Length > 4)
                      {
-                         t5 = JsonSerializer.Deserialize<TResult5>(payloads[4]);
+                         t5 = JsonSerializer.Deserialize<TResult5>(payloads[4], this.Options.JsonHubProtocolOptions.PayloadSerializerOptions);
                      }
                      if (payloads.Length > 5)
                      {
-                         t6 = JsonSerializer.Deserialize<TResult6>(payloads[5]);
+                         t6 = JsonSerializer.Deserialize<TResult6>(payloads[5], this.Options.JsonHubProtocolOptions.PayloadSerializerOptions);
                      }
                      if (payloads.Length > 6)
                      {
-                         t7 = JsonSerializer.Deserialize<TResult7>(payloads[6]);
+                         t7 = JsonSerializer.Deserialize<TResult7>(payloads[6], this.Options.JsonHubProtocolOptions.PayloadSerializerOptions);
                      }
                      if (payloads.Length > 7)
                      {
-                         t8 = JsonSerializer.Deserialize<TResult8>(payloads[7]);
+                         t8 = JsonSerializer.Deserialize<TResult8>(payloads[7], this.Options.JsonHubProtocolOptions.PayloadSerializerOptions);
                      }
                      if (payloads.Length > 8)
                      {
-                         t9 = JsonSerializer.Deserialize<TResult9>(payloads[8]);
+                         t9 = JsonSerializer.Deserialize<TResult9>(payloads[8], this.Options.JsonHubProtocolOptions.PayloadSerializerOptions);
                      }
                      if (payloads.Length > 9)
                      {
-                         t10 = JsonSerializer.Deserialize<TResult10>(payloads[9]);
+                         t10 = JsonSerializer.Deserialize<TResult10>(payloads[9], this.Options.JsonHubProtocolOptions.PayloadSerializerOptions);
                      }
 
                      return handler(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10);

--- a/src/Blazor.Extensions.SignalR/HubConnectionBuilder.cs
+++ b/src/Blazor.Extensions.SignalR/HubConnectionBuilder.cs
@@ -67,5 +67,31 @@ namespace Blazor.Extensions
             hubConnectionBuilder.Options.EnableMessagePack = true;
             return hubConnectionBuilder;
         }
+
+        /// <summary>
+        /// Enables the Json protocol for SignalR.
+        /// </summary>
+        /// <param name="hubConnectionBuilder">The <see cref="HubConnectionBuilder"/> representing the SignalR server to add Json protocol support to. Disables MessagePack protocol support.</param>
+        /// <returns>The same instance of the <see cref="HubConnectionBuilder"/> for chaining.</returns>
+        public static HubConnectionBuilder AddJsonProtocol(this HubConnectionBuilder hubConnectionBuilder)
+        {
+            if (hubConnectionBuilder == null) throw new ArgumentNullException(nameof(hubConnectionBuilder));
+            hubConnectionBuilder.Options.EnableMessagePack = false;
+            return hubConnectionBuilder;
+        }
+
+        /// <summary>
+        /// Enables the Json protocol for SignalR.
+        /// </summary>
+        /// <param name="hubConnectionBuilder">The <see cref="HubConnectionBuilder"/> representing the SignalR server to add Json protocol support to. Disables MessagePack protocol support.</param>
+        /// <param name="configure">A delegate that can be used to configure the <see cref="JsonHubProtocolOptions"/>.</param>
+        /// <returns>The same instance of the <see cref="HubConnectionBuilder"/> for chaining.</returns>
+        public static HubConnectionBuilder AddJsonProtocol(this HubConnectionBuilder hubConnectionBuilder, Action<JsonHubProtocolOptions> configure)
+        {
+            if (hubConnectionBuilder == null) throw new ArgumentNullException(nameof(hubConnectionBuilder));
+            hubConnectionBuilder.Options.EnableMessagePack = false;
+            configure.Invoke(hubConnectionBuilder.Options.JsonHubProtocolOptions);
+            return hubConnectionBuilder;
+        }
     }
 }

--- a/src/Blazor.Extensions.SignalR/JsonHubProtocolOptions.cs
+++ b/src/Blazor.Extensions.SignalR/JsonHubProtocolOptions.cs
@@ -1,0 +1,7 @@
+namespace Blazor.Extensions
+{
+    public class JsonHubProtocolOptions
+    {
+        public System.Text.Json.JsonSerializerOptions PayloadSerializerOptions { get; set; } = new System.Text.Json.JsonSerializerOptions();
+    }
+}


### PR DESCRIPTION
This pull request adds support for custom Json serializer options, in the same style as the .NET client.

This is relevant when using this together with F#, Bolero and `FSharp.SystemTextJson` package.