### PR TITLE
Use Microsoft.JSInterop instead of Microsoft.AspNetCore.Components.We…

### DIFF
--- a/src/Blazor.Extensions.SignalR/Blazor.Extensions.SignalR.csproj
+++ b/src/Blazor.Extensions.SignalR/Blazor.Extensions.SignalR.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.0-preview3.19555.2" />
+    <PackageReference Include="Microsoft.JSInterop" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Use **Microsoft.JSInterop** instead of Microsoft.AspNetCore.Components.Web" Version="3.1.0-**preview**3.19555.2"

I thinik it made also problems when hosted in Blazor web assembly, since its RC version use now "...Components.WebAssembly" rather then "Components.Web" nugets. They made some changes.

JSInterop, wehat is being used in this repo, has its own nuget. Just' let's use that basic one.